### PR TITLE
Fix typo on Hublo experience's end date

### DIFF
--- a/src/components/WorkTimeline/data.tsx
+++ b/src/components/WorkTimeline/data.tsx
@@ -138,7 +138,7 @@ const data: Data = [
     year: 2021,
     data: [
       {
-        date: 'November 2021 – January 2021',
+        date: 'November 2021 – January 2022',
         company: 'Hublo',
         companyUrl: 'https://hublo.com',
         place: 'Sophia-Antipolis, France',


### PR DESCRIPTION
Fixed a typo on the end date for experience at Hublo as per linkedin profile: January 2022. 

Just saying 👋 , I like the timeline on the website. 